### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/neuroelectro/neuroelectro_org.png?label=ready&title=Ready)](https://waffle.io/neuroelectro/neuroelectro_org)
 This is the public github repository for the NeuroElectro project. The project can be explored at http://neuroelectro.org.
 
 ![NeuroElectro Logo](https://raw.githubusercontent.com/neuroelectro/neuroelectro_org/master/media/images/neuroelectro.png)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/neuroelectro/neuroelectro_org

This was requested by a real person (user stripathy) on waffle.io, we're not trying to spam you.